### PR TITLE
Generate full PDF docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 1. In a terminal, navigate to the root directory of the documentation and build it `make`.
    Additional commands are available with `make help`.
 2. Open the file `documentation/_build/html/index.html` in your web browser.
-3. See [this guide](https://www.odoo.com/documentation/latest/contributing/documentation.html)
+3. To generate a PDF version of the documentation, run `make latexpdf`.
+   The resulting file is copied to `documentation/_build/html/`.
+4. See [this guide](https://www.odoo.com/documentation/latest/contributing/documentation.html)
    for more detailed instructions.
 
 Optional: place your local copy of the `odoo/odoo` and `odoo/upgrade-util` repositories in

--- a/conf.py
+++ b/conf.py
@@ -358,6 +358,12 @@ latex_documents = [
      'Termos Gerais de Venda Odoo', '', 'howto'),
 ]
 
+# Build a complete PDF of the documentation from the ``index`` page
+# to provide an offline version of all guides.
+latex_documents.append(
+    ('index', 'odoo_documentation.tex', 'Odoo Documentation', 'Odoo', 'manual')
+)
+
 # List of languages that have legal translations (excluding EN). The keys must be in
 # `languages_names`. These translations will have a link to their versions of the legal
 # contracts, instead of the default EN one. The main legal documents are not part of the


### PR DESCRIPTION
## Summary
- produce a unified PDF for the whole manual
- document PDF build instructions

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'sphinxlint')*

------
https://chatgpt.com/codex/tasks/task_e_686ddefbf7b48327b9afd03f26ccc87b