### PR TITLE
Add single PDF build target with fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for Sphinx documentation
+	# Makefile for Sphinx documentation
 
 # Pass WORKERS=1 for single-worker build
 ifndef WORKERS
@@ -35,7 +35,7 @@ endif
 
 #=== Standard rules ===#
 
-.PHONY: all help clean html latexpdf gettext fast static test review
+.PHONY: all help clean html latexpdf pdf gettext fast static test pdf-test review
 
 # In first position to build the documentation from scratch by default
 all: html
@@ -67,6 +67,13 @@ latexpdf:
 	cp $(BUILD_DIR)/latex/*.pdf $(BUILD_DIR)/html/
 	@echo "Build finished."
 
+pdf:
+	@echo "Starting single PDF build..."
+	$(SPHINX_BUILD) -c pdf_conf -b latex $(SPHINXOPTS) $(SOURCE_DIR) $(BUILD_DIR)/single_latex
+	$(MAKE) -C $(BUILD_DIR)/single_latex
+	cp $(BUILD_DIR)/single_latex/odoo_documentation.pdf $(BUILD_DIR)/
+	@echo "Build finished."
+
 gettext:
 	@echo "Generating translatable files..."
 	$(SPHINX_BUILD) -c $(CONFIG_DIR) -b gettext $(SOURCE_DIR) locale/sources
@@ -90,6 +97,9 @@ static: $(HTML_BUILD_DIR)/_static/style.css
 # Called by runbot for the ci/documentation_guideline check.
 test:
 	@python tests/main.py $(SOURCE_DIR)/administration $(SOURCE_DIR)/applications $(SOURCE_DIR)/contributing $(SOURCE_DIR)/developer redirects
+
+pdf-test:
+	@python tests/pdf_test.py
 
 # Similar as `test`, but called only manually by content reviewers to trigger extra checks.
 review:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@
 
 1. In a terminal, navigate to the root directory of the documentation and build it `make`.
    Additional commands are available with `make help`.
-2. Open the file `documentation/_build/html/index.html` in your web browser.
-3. See [this guide](https://www.odoo.com/documentation/latest/contributing/documentation.html)
+2. To generate a single PDF of the documentation run `make pdf`. The file will
+   be available at `_build/odoo_documentation.pdf`.
+3. Open the file `documentation/_build/html/index.html` in your web browser.
+4. See [this guide](https://www.odoo.com/documentation/latest/contributing/documentation.html)
    for more detailed instructions.
 
 Optional: place your local copy of the `odoo/odoo` and `odoo/upgrade-util` repositories in

--- a/pdf_conf/conf.py
+++ b/pdf_conf/conf.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import os
+import sys
+
+root_dir = Path(__file__).resolve().parents[1]
+os.chdir(root_dir)
+sys.path.insert(0, str(root_dir))
+from conf import *
+
+from extensions.custom_admonitions import (
+    example,
+    exercise,
+    DfnSpan,
+)
+
+# Use absolute path for logo to avoid missing file errors
+latex_logo = str(root_dir / 'static/img/odoo_logo.png')
+from extensions.cards import Div as CardDiv, A as CardA, Span as CardSpan, H4 as CardH4
+from extensions.spoilers import Container as SpoilerContainer, Header as SpoilerHeader, Button as SpoilerButton
+from extensions.html_domain import (
+    div as HtmlDiv,
+    address as HtmlAddress,
+    mark as HtmlMark,
+    insert as HtmlInsert,
+    delete as HtmlDelete,
+    strikethrough as HtmlStrikethrough,
+    underline as HtmlUnderline,
+    small as HtmlSmall,
+    kbd as HtmlKbd,
+    var as HtmlVar,
+    samp as HtmlSamp,
+    cite as HtmlCite,
+)
+
+def visit_admonition_latex(self, node):
+    self.visit_admonition(node)
+
+def depart_admonition_latex(self, node=None):
+    self.depart_admonition(node)
+
+
+def ignore_node(self, node):
+    """Ignore custom nodes when building LaTeX."""
+    pass
+
+def setup(app):
+    app.add_node(example, latex=(visit_admonition_latex, depart_admonition_latex))
+    app.add_node(exercise, latex=(visit_admonition_latex, depart_admonition_latex))
+    for node in [
+        CardDiv,
+        CardA,
+        CardSpan,
+        CardH4,
+        SpoilerContainer,
+        SpoilerHeader,
+        SpoilerButton,
+        DfnSpan,
+        HtmlDiv,
+        HtmlAddress,
+        HtmlMark,
+        HtmlInsert,
+        HtmlDelete,
+        HtmlStrikethrough,
+        HtmlUnderline,
+        HtmlSmall,
+        HtmlKbd,
+        HtmlVar,
+        HtmlSamp,
+        HtmlCite,
+    ]:
+        app.add_node(node, latex=(ignore_node, ignore_node))
+
+latex_documents = [
+    ('index', 'odoo_documentation.pdf', 'Odoo Documentation', '', 'manual'),
+]

--- a/tests/pdf_sample/bar.rst
+++ b/tests/pdf_sample/bar.rst
@@ -1,0 +1,4 @@
+Bar
+===
+
+Bar page content.

--- a/tests/pdf_sample/conf.py
+++ b/tests/pdf_sample/conf.py
@@ -1,0 +1,6 @@
+project = 'Sample'
+master_doc = 'index'
+extensions = []
+latex_documents = [
+    ('index', 'sample.pdf', 'Sample Documentation', '', 'manual'),
+]

--- a/tests/pdf_sample/foo.rst
+++ b/tests/pdf_sample/foo.rst
@@ -1,0 +1,4 @@
+Foo
+===
+
+Foo page content.

--- a/tests/pdf_sample/index.rst
+++ b/tests/pdf_sample/index.rst
@@ -1,0 +1,8 @@
+Sample Documentation
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   foo
+   bar

--- a/tests/pdf_test.py
+++ b/tests/pdf_test.py
@@ -1,0 +1,19 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+BUILD_DIR = Path('_build/test_pdf')
+
+if BUILD_DIR.exists():
+    shutil.rmtree(BUILD_DIR)
+
+subprocess.check_call([
+    'sphinx-build', '-c', 'tests/pdf_sample', '-b', 'latex',
+    'tests/pdf_sample', str(BUILD_DIR / 'latex')
+])
+subprocess.check_call(['make', '-C', str(BUILD_DIR / 'latex')])
+
+pdfs = list((BUILD_DIR / 'latex').glob('*.pdf'))
+if not pdfs:
+    raise SystemExit('PDF not generated')
+print('PDF generated:', pdfs[0])


### PR DESCRIPTION
## Summary
- document generating a single PDF with `make pdf`
- add a `pdf` rule in the Makefile and sample pdf test
- configure pdf build to ignore custom nodes so Sphinx can build

## Testing
- `make pdf-test`
- `make pdf`


------
https://chatgpt.com/codex/tasks/task_e_686df9e749c48327b3d1641153835d43